### PR TITLE
Windows os and quality fixes

### DIFF
--- a/extendedstoreconnection/impls/filesystemstoreconnection/src/main/java/org/adorsys/encobject/filesystem/ZipFileHelper.java
+++ b/extendedstoreconnection/impls/filesystemstoreconnection/src/main/java/org/adorsys/encobject/filesystem/ZipFileHelper.java
@@ -1,5 +1,19 @@
 package org.adorsys.encobject.filesystem;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.nio.file.FileSystemException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
 import org.adorsys.cryptoutils.exceptions.BaseExceptionHandler;
 import org.adorsys.encobject.complextypes.BucketDirectory;
 import org.adorsys.encobject.complextypes.BucketPath;
@@ -15,18 +29,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.nio.file.FileSystemException;
-import java.util.UUID;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
-import java.util.zip.ZipOutputStream;
 
 /**
  * Created by peter on 21.02.18 at 19:31.
@@ -54,7 +56,6 @@ public class ZipFileHelper {
      */
     public void writeZip(BucketPath bucketPath, SimplePayloadImpl payload) {
 
-        ZipOutputStream zos = null;
         try {
             payload.getStorageMetadata().setType(StorageType.BLOB);
             payload.getStorageMetadata().setName(BucketPathUtil.getAsString(bucketPath));
@@ -67,45 +68,37 @@ public class ZipFileHelper {
             }
             LOGGER.debug("write temporary zip file to " + tempFile);
 
-            zos = new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(tempFile)));
+            try (ZipOutputStream zos = new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(tempFile)))) {
 
-            zos.putNextEntry(new ZipEntry(ZIP_STORAGE_METADATA_JSON));
-            String jsonString = gsonHelper.toJson(payload.getStorageMetadata());
-            LOGGER.debug("WRITE metadata " + jsonString + " with charset " + CHARSET_NAME);
-            byte[] storageMetadata = jsonString.getBytes(CHARSET_NAME);
-            zos.write(storageMetadata, 0, storageMetadata.length);
-            zos.closeEntry();
-
-            zos.putNextEntry(new ZipEntry(ZIP_CONTENT_BINARY));
-            zos.write(content, 0, content.length);
-            zos.closeEntry();
-
-            zos.close();
-            zos = null;
+	            zos.putNextEntry(new ZipEntry(ZIP_STORAGE_METADATA_JSON));
+	            String jsonString = gsonHelper.toJson(payload.getStorageMetadata());
+	            LOGGER.debug("WRITE metadata " + jsonString + " with charset " + CHARSET_NAME);
+	            byte[] storageMetadata = jsonString.getBytes(CHARSET_NAME);
+	            zos.write(storageMetadata, 0, storageMetadata.length);
+	            zos.closeEntry();
+	
+	            zos.putNextEntry(new ZipEntry(ZIP_CONTENT_BINARY));
+	            zos.write(content, 0, content.length);
+	            zos.closeEntry();
+            }
 
             File origFile = BucketPathFileHelper.getAsFile(baseDir.append(bucketPath.add(ZIP_SUFFIX)), absolutePath);
+            /*
             if (origFile.exists()) {
                 LOGGER.debug("ACHTUNG, file existiert bereits, wird nun neu verlinkt " + bucketPath);
                 FileUtils.forceDelete(origFile);
             }
             FileUtils.moveFile(tempFile, origFile);
+            */
+            // This should work much faster as the above code, because there is no need to delete the file
+            Files.move(tempFile.toPath(), origFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
         } catch (Exception e) {
             throw BaseExceptionHandler.handle(e);
-        } finally {
-            if (zos != null) {
-                try {
-                    zos.close();
-                } catch (Exception e) {
-                    LOGGER.error("error during close of zip output stream for file " + bucketPath);
-                }
-            }
         }
     }
 
     public void writeZipStream(BucketPath bucketPath, SimplePayloadStreamImpl payloadStream) {
 
-        ZipOutputStream zos = null;
-        InputStream is = null;
         try {
             payloadStream.getStorageMetadata().setType(StorageType.BLOB);
             payloadStream.getStorageMetadata().setName(BucketPathUtil.getAsString(bucketPath));
@@ -120,20 +113,16 @@ public class ZipFileHelper {
             }
             LOGGER.debug("write temporary zip file to " + tempFile);
 
-            zos = new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(tempFile)));
+            try (ZipOutputStream zos = new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(tempFile)))) {
+            	zos.putNextEntry(new ZipEntry(ZIP_STORAGE_METADATA_JSON));
+                zos.write(storageMetadata, 0, storageMetadata.length);
+                zos.closeEntry();
 
-            zos.putNextEntry(new ZipEntry(ZIP_STORAGE_METADATA_JSON));
-            zos.write(storageMetadata, 0, storageMetadata.length);
-            zos.closeEntry();
-
-            is = payloadStream.openStream();
-            zos.putNextEntry(new ZipEntry(ZIP_CONTENT_BINARY));
-            IOUtils.copy(is, zos);
-
-            IOUtils.closeQuietly(is);
-            is = null;
-            IOUtils.closeQuietly(zos);
-            zos = null;
+                try (InputStream is = payloadStream.openStream()) {
+                	zos.putNextEntry(new ZipEntry(ZIP_CONTENT_BINARY));
+                    IOUtils.copy(is, zos);
+                }    
+            }
 
             File origFile = BucketPathFileHelper.getAsFile(baseDir.append(bucketPath.add(ZIP_SUFFIX)), absolutePath);
             if (origFile.exists()) {
@@ -143,13 +132,6 @@ public class ZipFileHelper {
             FileUtils.moveFile(tempFile, origFile);
         } catch (Exception e) {
             throw BaseExceptionHandler.handle(e);
-        } finally {
-            if (zos != null) {
-                IOUtils.closeQuietly(zos);
-            }
-            if (is != null) {
-                IOUtils.closeQuietly(is);
-            }
         }
     }
 
@@ -161,20 +143,21 @@ public class ZipFileHelper {
             }
 
             File file = BucketPathFileHelper.getAsFile(baseDir.append(bucketPath.add(ZIP_SUFFIX)), absolutePath);
-            ZipInputStream zis = new ZipInputStream(new BufferedInputStream(new FileInputStream(file)));
-            ZipEntry entry;
-            byte[] data = null;
-            while ((entry = zis.getNextEntry()) != null) {
-                if (entry.getName().equals(ZIP_CONTENT_BINARY)) {
-                    data = IOUtils.toByteArray(zis);
+            try (ZipInputStream zis = new ZipInputStream(new BufferedInputStream(new FileInputStream(file)))) {
+            	ZipEntry entry;
+                byte[] data = null;
+                while ((entry = zis.getNextEntry()) != null) {
+                    if (entry.getName().equals(ZIP_CONTENT_BINARY)) {
+                        data = IOUtils.toByteArray(zis);
+                    }
+                    zis.closeEntry();
                 }
-                zis.closeEntry();
-            }
-            if (data == null) {
-                throw new StorageConnectionException("Zipfile " + bucketPath + " does not have entry for " + ZIP_CONTENT_BINARY);
-            }
-            Payload payload = new SimplePayloadImpl(storageMetadata, data);
-            return payload;
+                if (data == null) {
+                    throw new StorageConnectionException("Zipfile " + bucketPath + " does not have entry for " + ZIP_CONTENT_BINARY);
+                }
+                Payload payload = new SimplePayloadImpl(storageMetadata, data);
+                return payload;
+            }          
         } catch (Exception e) {
             throw BaseExceptionHandler.handle(e);
         }
@@ -187,15 +170,16 @@ public class ZipFileHelper {
             }
 
             File file = BucketPathFileHelper.getAsFile(baseDir.append(bucketPath.add(ZIP_SUFFIX)), absolutePath);
-            ZipInputStream zis = new ZipInputStream(new BufferedInputStream(new FileInputStream(file)));
-            ZipEntry entry;
-            while ((entry = zis.getNextEntry()) != null) {
-                if (entry.getName().equals(ZIP_CONTENT_BINARY)) {
-                    return new SimplePayloadStreamImpl(storageMetadata, zis);
-                }
-                zis.closeEntry();
+            try (ZipInputStream zis = new ZipInputStream(new BufferedInputStream(new FileInputStream(file)))) {
+	            ZipEntry entry;
+	            while ((entry = zis.getNextEntry()) != null) {
+	                if (entry.getName().equals(ZIP_CONTENT_BINARY)) {
+	                    return new SimplePayloadStreamImpl(storageMetadata, zis);
+	                }
+	                zis.closeEntry();
+	            }
+	            throw new StorageConnectionException("Zipfile " + bucketPath + " does not have entry for " + ZIP_CONTENT_BINARY);
             }
-            throw new StorageConnectionException("Zipfile " + bucketPath + " does not have entry for " + ZIP_CONTENT_BINARY);
         } catch (Exception e) {
             throw BaseExceptionHandler.handle(e);
         }
@@ -209,22 +193,24 @@ public class ZipFileHelper {
                 throw new FileSystemException("File does not exist" + bucketPath);
             }
 
-            ZipInputStream zis = new ZipInputStream(new BufferedInputStream(new FileInputStream(file)));
-            ZipEntry entry;
-            String jsonString = null;
-            while ((entry = zis.getNextEntry()) != null) {
-                if (entry.getName().equals(ZIP_STORAGE_METADATA_JSON)) {
-                    jsonString = new String(IOUtils.toByteArray(zis), CHARSET_NAME);
-                    LOGGER.debug("READ metadata string " + jsonString + "with " + CHARSET_NAME);
-                }
-                zis.closeEntry();
-            }
-            if (jsonString == null) {
-                throw new StorageConnectionException("Zipfile " + bucketPath + " does not have entry for " + ZIP_STORAGE_METADATA_JSON);
-            }
+            try (ZipInputStream zis = new ZipInputStream(new BufferedInputStream(new FileInputStream(file)))) {
+            	 ZipEntry entry;
+                 String jsonString = null;
+                 while ((entry = zis.getNextEntry()) != null) {
+                     if (entry.getName().equals(ZIP_STORAGE_METADATA_JSON)) {
+                         jsonString = new String(IOUtils.toByteArray(zis), CHARSET_NAME);
+                         LOGGER.debug("READ metadata string " + jsonString + "with " + CHARSET_NAME);
+                     }
+                     zis.closeEntry();
+                 }
+                 if (jsonString == null) {
+                     throw new StorageConnectionException("Zipfile " + bucketPath + " does not have entry for " + ZIP_STORAGE_METADATA_JSON);
+                 }
 
-            StorageMetadata storageMetadata = gsonHelper.fromJson(jsonString);
-            return storageMetadata;
+                 StorageMetadata storageMetadata = gsonHelper.fromJson(jsonString);
+                 return storageMetadata;
+            }
+           
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/extendedstoreconnection/impls/filesystemstoreconnection/src/test/java/org/adorsys/encobject/filesystem/AbsoluteAndRelativePathTest.java
+++ b/extendedstoreconnection/impls/filesystemstoreconnection/src/test/java/org/adorsys/encobject/filesystem/AbsoluteAndRelativePathTest.java
@@ -1,5 +1,8 @@
 package org.adorsys.encobject.filesystem;
 
+import java.io.File;
+import java.util.UUID;
+
 import org.adorsys.cryptoutils.exceptions.BaseExceptionHandler;
 import org.adorsys.encobject.complextypes.BucketDirectory;
 import org.adorsys.encobject.complextypes.BucketPath;
@@ -10,9 +13,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.File;
-import java.util.UUID;
 
 /**
  * Created by peter on 26.06.18 at 15:23.
@@ -44,7 +44,13 @@ public class AbsoluteAndRelativePathTest {
         try {
             String tmpdir = System.getProperty("java.io.tmpdir");
             LOGGER.debug("tempdir " + tmpdir);
-            Assert.assertTrue(tmpdir.startsWith(BucketPath.BUCKET_SEPARATOR));
+            if (File.separatorChar == '/') {
+            	Assert.assertTrue(tmpdir.startsWith(BucketPath.BUCKET_SEPARATOR));
+            } else {
+            	// Prevents "Bucket must not contain uppercase letters: C:\Users\XXX\AppData\Local\Temp\ on Windows
+            	tmpdir = tmpdir.toLowerCase();
+            }
+            
             if (!tmpdir.endsWith(BucketPath.BUCKET_SEPARATOR)) {
                 tmpdir = tmpdir + BucketPath.BUCKET_SEPARATOR;
             }

--- a/extendedstoreconnection/impls/storeconnectionfactory/src/test/java/org/adorsys/cryptoutils/storageconnection/testsuite/StorageMetaDataTest.java
+++ b/extendedstoreconnection/impls/storeconnectionfactory/src/test/java/org/adorsys/cryptoutils/storageconnection/testsuite/StorageMetaDataTest.java
@@ -1,8 +1,19 @@
 package org.adorsys.cryptoutils.storageconnection.testsuite;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import junit.framework.Assert;
+import java.io.File;
+import java.net.URI;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
 import org.adorsys.cryptoutils.exceptions.BaseException;
 import org.adorsys.cryptoutils.exceptions.BaseExceptionHandler;
 import org.adorsys.cryptoutils.storeconnectionfactory.ExtendedStoreConnectionFactory;
@@ -18,19 +29,17 @@ import org.adorsys.encobject.service.api.ExtendedStoreConnection;
 import org.adorsys.encobject.service.impl.SimpleLocationImpl;
 import org.adorsys.encobject.service.impl.SimplePayloadImpl;
 import org.adorsys.encobject.service.impl.SimpleStorageMetadataImpl;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.net.URI;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.text.SimpleDateFormat;
-import java.util.*;
-import java.util.stream.Collectors;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import junit.framework.Assert;
 
 /**
  * Created by peter on 20.02.18 at 16:53.
@@ -221,7 +230,7 @@ public class StorageMetaDataTest {
      * logback benötigt, denn der Simpple-Logger schreibt nicht in Dateien.
      */
     @Test
-    public void checkMetaInfoOnlyReadOnceForDocument() {
+    public void testCheckMetaInfoOnlyReadOnceForDocument() {
         try {
             String logfilename = "storeconnectionfactory-test-log-file.log";
             LOGGER.debug("START TEST " + new RuntimeException("").getStackTrace()[0].getMethodName());
@@ -464,7 +473,9 @@ public class StorageMetaDataTest {
                     throw new BaseException("Did not find unique entry in logfile for " + MAX_WAIT + " seconds.");
                 }
                 Thread.currentThread().sleep(1000);
-                count = Files.lines(Paths.get(logfilename))
+                
+                // Without the Charset, we get "java.nio.charset.MalformedInputException: Input length = 1" on Windows
+                count = Files.lines(Paths.get(logfilename), SystemUtils.IS_OS_WINDOWS ? Charset.forName("Cp1252") : Charset.defaultCharset())
                         .filter(line -> line.indexOf(unique) != -1)
                         .collect(Collectors.toSet())
                         .size();
@@ -484,7 +495,8 @@ public class StorageMetaDataTest {
                         + new java.io.File(".").getCanonicalPath()
                         + "This tests requires the logfilefile to succeed.");
             }
-            return Files.lines(Paths.get(logfilename))
+            // Without the Charset, we get "java.nio.charset.MalformedInputException: Input length = 1" on Windows
+            return Files.lines(Paths.get(logfilename), SystemUtils.IS_OS_WINDOWS ? Charset.forName("Cp1252") : Charset.defaultCharset())
                     .filter(line -> line.indexOf("SPECIAL_LOGGER") != -1)
                     .filter(line -> line.indexOf("readmetadata ") != -1)
              //       .filter(line -> line.indexOf(searchname) != -1)


### PR DESCRIPTION
The build (tests) haven't worked under Windows OS.
I have fixed the tests (drive letters) and especially the ZipFileHelper class (multiple unclosed resources) and RealAmazonS3ExtendedStoreConnection. Windows is very strict and cannot delete files with open file handles! This is the pull request for the changes.

_**Hint:**_ There is still one open issue: The test _writeWithStreamAndLoadBytesAndStream_ in _EncryptedPersistenceServiceTest.java_. The test stills fails under Windows with `java.io.IOException Stream closed` in `org.adorsys.encobject.service.VerySimpleEncryptionService$VerySimpleEncryptionStream.read(VerySimpleEncryptionService.java:34)`. It is difficult to fix it, because in the code

```
    @Override
    public void encryptAndPersistStream(BucketPath bucketPath, PayloadStream payloadStream, KeySource
            keySource, KeyID keyID) {
        payloadStream.getStorageMetadata().getUserMetadata().put(ENCRYPTION_SERVICE, encryptionStreamService.getClass().toString());
        payloadStream.getStorageMetadata().getUserMetadata().put(ENCRYPTION_KEY_ID, keyID.getValue());
        LOGGER.debug("ENCRYPT STREAM WITH " + keyID);
        InputStream encryptedStream = encryptionStreamService.getEncryptedInputStream(payloadStream.getStorageMetadata().getUserMetadata(), payloadStream.openStream(), keySource, keyID, payloadStream.getStorageMetadata().getShouldBeCompressed());
        extendedStoreConnection.putBlobStream(bucketPath, new SimplePayloadStreamImpl(payloadStream.getStorageMetadata(), encryptedStream));
    }
```
it is unclear which component is responsible for closing with stream!
