### PR TITLE
Switch from OracleJDK8 to OpenJDK8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 script:
   - mvn --settings .travis/settings.xml clean verify -B -V


### PR DESCRIPTION
Oracle has changed the nature of OracleJDK8.

It will not be possible to use JDK 8 for commercial purposes without additional costs.
See https://www.oracle.com/technetwork/java/java-se-support-roadmap.html

OpenJDK8 is the free alternative.